### PR TITLE
SysUI: Use VectorDrawable's for rendering battery

### DIFF
--- a/graphics/java/android/graphics/drawable/StopMotionVectorDrawable.java
+++ b/graphics/java/android/graphics/drawable/StopMotionVectorDrawable.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2016 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package android.graphics.drawable;
+
+import android.animation.Animator;
+import android.animation.AnimatorSet;
+import android.animation.ValueAnimator;
+import android.graphics.drawable.AnimatedVectorDrawable;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.DrawableWrapper;
+import android.util.Log;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+
+/**
+ * Wraps an {@link AnimatedVectorDrawable} and provides methods for setting the temporal position
+ * within the backing {@link AnimatorSet} of the wrapped {@link AnimatedVectorDrawable}.
+ */
+public class StopMotionVectorDrawable extends DrawableWrapper {
+    private static final String TAG = StopMotionVectorDrawable.class.getSimpleName();
+
+    private AnimatedVectorDrawable mDrawable;
+    private AnimatorSet mAnimatorSet;
+
+    /**
+     * Creates a new wrapper around the specified drawable.
+     *
+     * @param dr The drawable to wrap.  Must be an {@link AnimatedVectorDrawable}
+     */
+    public StopMotionVectorDrawable(Drawable dr) {
+        super(dr);
+        setDrawable(dr);
+    }
+
+    /**
+     * {@see DrawableWrapper$setDrawable}
+     * @param dr the wrapped drawable
+     * @throws IllegalArgumentException IF drawable is not an {@link AnimatedVectorDrawable}
+     */
+    @Override
+    public void setDrawable(Drawable dr) {
+        if (dr != null && !(dr instanceof AnimatedVectorDrawable)) {
+            throw new IllegalArgumentException("Drawable must be an AnimatedVectorDrawable");
+        }
+
+        super.setDrawable(dr);
+        mDrawable = (AnimatedVectorDrawable) dr;
+        if (mDrawable != null) {
+            mDrawable.reset();
+            getAnimatorSetViaReflection();
+        }
+    }
+
+    /**
+     * {@see android.animation.ValueAnimator#setCurrentFraction}
+     * @param fraction The fraction to which the animation is advanced or rewound. Values outside
+     *                 the range of 0 to the maximum fraction for the animator will be clamped to
+     *                 the correct range.
+     */
+    public void setCurrentFraction(float fraction) {
+        if (mDrawable == null || mAnimatorSet == null) return;
+
+        ArrayList<Animator> animators = mAnimatorSet.getChildAnimations();
+        for (Animator animator : animators) {
+            if (animator instanceof ValueAnimator) {
+                ((ValueAnimator) animator).setCurrentFraction(fraction);
+            }
+        }
+
+        mDrawable.invalidateSelf();
+    }
+
+    private void getAnimatorSetViaReflection() {
+        try {
+            Field _mAnimatorSet = AnimatedVectorDrawable.class.getDeclaredField("mAnimatorSet");
+            _mAnimatorSet.setAccessible(true);
+            Class<?> innerClazz = Class.forName("android.graphics.drawable.AnimatedVectorDrawable$VectorDrawableAnimatorUI");
+            mDrawable.forceAnimationOnUI();
+            Object _inner = _mAnimatorSet.get(mDrawable);
+            Field _mSet = innerClazz.getDeclaredField("mSet");
+            _mSet.setAccessible(true);
+            mAnimatorSet = (AnimatorSet) _mSet.get(_inner);
+        } catch (NoSuchFieldException | IllegalAccessException | ClassNotFoundException e) {
+            Log.e(TAG, "Could not get mAnimatorSet via reflection", e);
+        }
+    }
+}

--- a/packages/SystemUI/res/anim/battery_circle.xml
+++ b/packages/SystemUI/res/anim/battery_circle.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<objectAnimator
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:interpolator="@android:interpolator/linear"
+  android:propertyName="trimPathEnd"
+  android:valueFrom="0"
+  android:valueTo="1"
+  android:valueType="floatType" />

--- a/packages/SystemUI/res/anim/battery_landscape.xml
+++ b/packages/SystemUI/res/anim/battery_landscape.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<objectAnimator
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:interpolator="@android:interpolator/linear"
+  android:propertyName="pathData"
+  android:valueFrom="@string/battery_landscape_path_empty"
+  android:valueTo="@string/battery_landscape_path_full"
+  android:valueType="pathType" />

--- a/packages/SystemUI/res/drawable/ic_battery_circle.xml
+++ b/packages/SystemUI/res/drawable/ic_battery_circle.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/battery_frame"
+        android:drawable="@drawable/ic_battery_circle_frame" />
+
+    <item
+        android:id="@+id/battery_fill"
+        android:drawable="@drawable/ic_battery_circle_avd" />
+
+    <item
+        android:id="@+id/battery_charge_indicator"
+        android:drawable="@drawable/ic_battery_bolt" />
+
+</layer-list>

--- a/packages/SystemUI/res/drawable/ic_battery_circle_avd.xml
+++ b/packages/SystemUI/res/drawable/ic_battery_circle_avd.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/ic_battery_circle_fill" >
+
+    <target
+        android:name="battery_level"
+        android:animation="@anim/battery_circle" />
+
+</animated-vector>

--- a/packages/SystemUI/res/drawable/ic_battery_circle_fill.xml
+++ b/packages/SystemUI/res/drawable/ic_battery_circle_fill.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- Path will be tinted based on battery level -->
+    <path
+        android:name="battery_level"
+        android:strokeColor="#000000"
+        android:strokeLineJoin="round"
+        android:strokeWidth="3"
+        android:pathData="@string/battery_circle_path" />
+</vector>

--- a/packages/SystemUI/res/drawable/ic_battery_circle_frame.xml
+++ b/packages/SystemUI/res/drawable/ic_battery_circle_frame.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- Path will be tinted based on light/dark modes -->
+    <path
+        android:name="frame"
+        android:strokeColor="#000000"
+        android:strokeLineJoin="round"
+        android:strokeWidth="3"
+        android:pathData="@string/battery_circle_path" />
+
+</vector>

--- a/packages/SystemUI/res/drawable/ic_battery_landscape.xml
+++ b/packages/SystemUI/res/drawable/ic_battery_landscape.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/battery_frame"
+        android:drawable="@drawable/ic_battery_landscape_frame" />
+
+    <item
+        android:id="@+id/battery_fill"
+        android:drawable="@drawable/ic_battery_landscape_avd" />
+
+    <item
+        android:id="@+id/battery_charge_indicator">
+        <rotate
+            android:pivotX="50%"
+            android:pivotY="50%"
+            android:fromDegrees="90"
+            android:toDegrees="90"
+            android:drawable="@drawable/ic_battery_bolt" />
+    </item>
+
+</layer-list>

--- a/packages/SystemUI/res/drawable/ic_battery_landscape_avd.xml
+++ b/packages/SystemUI/res/drawable/ic_battery_landscape_avd.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/ic_battery_landscape_fill" >
+
+    <target
+        android:name="battery_level"
+        android:animation="@anim/battery_landscape" />
+
+</animated-vector>

--- a/packages/SystemUI/res/drawable/ic_battery_landscape_fill.xml
+++ b/packages/SystemUI/res/drawable/ic_battery_landscape_fill.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="26dp"
+    android:height="24dp"
+    android:viewportWidth="26"
+    android:viewportHeight="24">
+
+    <clip-path
+        android:name="mask"
+        android:pathData="@string/battery_landscape_clip_path" />
+
+    <!-- Path will be tinted based on battery level -->
+    <path
+        android:name="battery_level"
+        android:fillColor="#000000"
+        android:pathData="@string/battery_landscape_path_empty" />
+
+</vector>

--- a/packages/SystemUI/res/drawable/ic_battery_landscape_frame.xml
+++ b/packages/SystemUI/res/drawable/ic_battery_landscape_frame.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="26dp"
+    android:height="24dp"
+    android:viewportWidth="26"
+    android:viewportHeight="24">
+
+    <clip-path
+        android:name="mask"
+        android:pathData="@string/battery_landscape_clip_path" />
+
+    <!-- Path will be tinted based on light/dark modes -->
+    <path
+        android:name="frame"
+        android:fillColor="#000000"
+        android:pathData="M 1 4 H 25 V 20 H 1 V 4 Z" />
+</vector>

--- a/packages/SystemUI/res/values/custom_strings.xml
+++ b/packages/SystemUI/res/values/custom_strings.xml
@@ -123,4 +123,12 @@
     <string name="quick_settings_location_high_accuracy_label">High accuracy</string>
     <string name="quick_settings_location_off_label">Location off</string>
     <string name="quick_settings_location_off_custom_label">Location</string>
+
+    <!-- Path data for landscape battery -->
+    <string name="battery_landscape_path_full" translatable="false">M 1 4 H 25 V 20 H 1 V 4 Z</string>
+    <string name="battery_landscape_path_empty" translatable="false">M 1 4 H 1 V 20 H 1 V 4 Z</string>
+    <string name="battery_landscape_clip_path" translatable="false">M25,16h-2v4H1V4h22v4h2V16z</string>
+
+    <!-- Path data for circle battery -->
+    <string name="battery_circle_path" translatable="false">M 12 3.5 C 16.6944203736 3.5 20.5 7.30557962644 20.5 12 C 20.5 16.6944203736 16.6944203736 20.5 12 20.5 C 7.30557962644 20.5 3.5 16.6944203736 3.5 12 C 3.5 7.30557962644 7.30557962644 3.5 12 3.5 Z</string>
 </resources>

--- a/packages/SystemUI/res/values/custom_styles.xml
+++ b/packages/SystemUI/res/values/custom_styles.xml
@@ -25,7 +25,11 @@
 
     <!-- Battery meter drawable styles -->
     <style name="BatteryMeterViewDrawable.Portrait"/>
-
+    <style name="BatteryMeterViewDrawable.Landscape"/>
+    <style name="BatteryMeterViewDrawable.Circle">
+        <item name="blendMode">overlay</item>
+    </style>
+    
     <!-- Status bar notification ticker -->
     <style name="TextAppearance.StatusBar.PhoneTicker"
         parent="@*android:style/TextAppearance.StatusBar.Ticker">

--- a/packages/SystemUI/src/com/android/systemui/BatteryMeterDrawable.java
+++ b/packages/SystemUI/src/com/android/systemui/BatteryMeterDrawable.java
@@ -38,6 +38,7 @@ import android.graphics.drawable.AnimatedVectorDrawable;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
+import android.graphics.drawable.StopMotionVectorDrawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
@@ -186,10 +187,10 @@ public class BatteryMeterDrawable extends Drawable implements
         final int resId = getBatteryDrawableStyleResourceForStyle(style);
         PorterDuff.Mode xferMode = PorterDuff.Mode.XOR;
         if (resId != 0) {
-            TypedArray a = mContext.obtainStyledAttributes(resId, attrs);
+            TypedArray a = mContext.obtainStyledAttributes(
+                    getBatteryDrawableStyleResourceForStyle(style), attrs);
             mTextGravity = a.getInt(0, Gravity.CENTER);
             xferMode = PorterDuff.intToMode(a.getInt(1, PorterDuff.modeToInt(PorterDuff.Mode.XOR)));
-            a.recycle();
         } else {
             mTextGravity = Gravity.CENTER;
         }
@@ -393,11 +394,6 @@ public class BatteryMeterDrawable extends Drawable implements
 
     @Override
     public void draw(Canvas c) {
-        final boolean showChargingAnim
-                = mContext.getResources().getBoolean(R.bool.config_show_battery_charging_anim);
-        final int level = showChargingAnim
-                ? updateChargingAnimLevel()
-                : mLevel;
         if (!mInitialized) {
             init();
         }
@@ -433,14 +429,8 @@ public class BatteryMeterDrawable extends Drawable implements
     }
 
     private void loadBatteryDrawables(Resources res, int style) {
-        try {
-            checkBatteryMeterDrawableValid(res, style);
-        } catch (BatteryMeterDrawableException e) {
-            Log.w(TAG, "Invalid themed battery meter drawable, falling back to system", e);
-        }
-
         final int drawableResId = getBatteryDrawableResourceForStyle(style);
-        mBatteryDrawable = (LayerDrawable) res.getDrawable(drawableResId, null);
+        mBatteryDrawable = (LayerDrawable) res.getDrawable(drawableResId);
         mFrameDrawable = mBatteryDrawable.findDrawableByLayerId(R.id.battery_frame);
         mFrameDrawable.setTint(mCurrentBackgroundColor != 0
                 ? mCurrentBackgroundColor : res.getColor(R.color.batterymeter_frame_color));
@@ -454,7 +444,7 @@ public class BatteryMeterDrawable extends Drawable implements
         final int resId = getBatteryDrawableResourceForStyle(style);
         final Drawable batteryDrawable;
         try {
-            batteryDrawable = res.getDrawable(resId, null);
+            batteryDrawable = res.getDrawable(resId);
         } catch (Resources.NotFoundException e) {
             throw new BatteryMeterDrawableException(res.getResourceName(resId) + " is an " +
                     "invalid drawable", e);
@@ -499,6 +489,10 @@ public class BatteryMeterDrawable extends Drawable implements
 
     private int getBatteryDrawableResourceForStyle(final int style) {
         switch (style) {
+            case BATTERY_STYLE_LANDSCAPE:
+                return R.drawable.ic_battery_landscape;
+            case BATTERY_STYLE_CIRCLE:
+                return R.drawable.ic_battery_circle;
             case BATTERY_STYLE_PORTRAIT:
                 return R.drawable.ic_battery_portrait;
             default:
@@ -508,6 +502,10 @@ public class BatteryMeterDrawable extends Drawable implements
 
     private int getBatteryDrawableStyleResourceForStyle(final int style) {
         switch (style) {
+            case BATTERY_STYLE_LANDSCAPE:
+                return R.style.BatteryMeterViewDrawable_Landscape;
+            case BATTERY_STYLE_CIRCLE:
+                return R.style.BatteryMeterViewDrawable_Circle;
             case BATTERY_STYLE_PORTRAIT:
                 return R.style.BatteryMeterViewDrawable_Portrait;
             default:

--- a/packages/SystemUI/src/com/android/systemui/BatteryMeterView.java
+++ b/packages/SystemUI/src/com/android/systemui/BatteryMeterView.java
@@ -135,7 +135,7 @@ public class BatteryMeterView extends ImageView implements
                 setImageDrawable(null);
                 break;
             default:
-                mDrawable = new BatteryMeterDrawable(mContext, new Handler(), mFrameColor);
+                mDrawable = new BatteryMeterDrawable(mContext, new Handler(), mFrameColor, style);
                 setImageDrawable(mDrawable);
                 setVisibility(View.VISIBLE);
                 break;


### PR DESCRIPTION
The current implementation of BatteryMeterView uses arrays of points
that are drawn programmatically.  This limits the ability to overlay
or theme the battery.  By utilizing VectorDrawables and
AnimatedVectorDrawables we can achieve the same look and feel of
stock while allowing for more unique battery meters.

Forward port the AVD battery commits from CM 13.0:
db5cf5dc36c629b9afba8f883ef5e33a33608409 SysUI: Use VectorDrawable's for rendering battery
d37a5aa57bb1c5d958abe036b5558ba4dac270c5 SysUI: Fix coloring of frame and bolt
2b21b18e109ddab30d7a0ff47dd900e55167ec37 SysUI: Use linear interpolator for battery level
5953be013f1f3fe14b5f4176b743c4032e114bfc SysUI: Allow styling of battery text/charge blend mode
e3ddac3a775d2e8808da40d302794e9b50016d9b SysUI: Adjust battery dimensions for better look
1530ec9e734cae8bfd966f3c43b3be9041386c29 SystemUI: Set circle battery path as untranslatable

TODO: Make portrait battery fill a larger proportion of the view
      Make landscape battery thinner in height
      Implement plus paint
      Fill the bolt paint

Change-Id: I91b4f5229774c979a7aa9ab771ffcb95ceb71b84